### PR TITLE
Fix/add people query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes between versions
 
+## 4.0.0 (2020-08-19)
+
+ * fixed the `/assignments` "`state`" query parameter description
+ * added the "`state`" query parameter on the `/people` endpoint
+
 ## 3.0.0 (2020-08-06)
 
 * Upgrade to Jane 6.0

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ dump($clients);
 dump($assignments);
 ```
 
+In the above example, the `$client` variable is an instance of the [Client](./generated/Client.php) class, which you can browse through to learn more about the API features.
+
 Want more example or documentation? See the [documentation](doc/index.md).
 
 ## Troubleshoot

--- a/Resources/forecast-openapi.yaml
+++ b/Resources/forecast-openapi.yaml
@@ -161,7 +161,7 @@ paths:
             type: string
             format: date
         - name: state
-          description: Only return assignments before this date
+          description: Pass "active" to only return assignments for currently active users
           required: false
           in: query
           schema:
@@ -314,6 +314,16 @@ paths:
       security:
         - BearerAuth: []
           AccountAuth: []
+      parameters:
+        - name: state
+          description: Pass "active" to only return active users. Any other value also returns archived users.
+          required: false
+          in: query
+          schema:
+            type: string
+            enum:
+              - active
+              - archived
       responses:
         "200":
           description: People list

--- a/generated/Client.php
+++ b/generated/Client.php
@@ -72,7 +72,7 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
      *     @var int $repeated_assignment_set Only return assignments for this repeated assignment set
      *     @var string $start_date Only return assignments after this date
      *     @var string $end_date Only return assignments before this date
-     *     @var string $state Only return assignments before this date
+     *     @var string $state Pass "active" to only return assignments for currently active users
      * }
      *
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
@@ -133,13 +133,20 @@ class Client extends \Jane\OpenApiRuntime\Client\Psr18Client
     }
 
     /**
+     * Returns a list of people.
+     *
+     * @param array $queryParameters {
+     *
+     *     @var string $state Pass "active" to only return active users. Any other value also returns archived users.
+     * }
+     *
      * @param string $fetch Fetch mode to use (can be OBJECT or RESPONSE)
      *
      * @return \JoliCode\Forecast\Api\Model\People|\JoliCode\Forecast\Api\Model\Error|\Psr\Http\Message\ResponseInterface|null
      */
-    public function listPeople(string $fetch = self::FETCH_OBJECT)
+    public function listPeople(array $queryParameters = [], string $fetch = self::FETCH_OBJECT)
     {
-        return $this->executePsr7Endpoint(new \JoliCode\Forecast\Api\Endpoint\ListPeople(), $fetch);
+        return $this->executePsr7Endpoint(new \JoliCode\Forecast\Api\Endpoint\ListPeople($queryParameters), $fetch);
     }
 
     /**

--- a/generated/Endpoint/ListAssignments.php
+++ b/generated/Endpoint/ListAssignments.php
@@ -25,7 +25,7 @@ class ListAssignments extends \Jane\OpenApiRuntime\Client\BaseEndpoint implement
      *     @var int $repeated_assignment_set Only return assignments for this repeated assignment set
      *     @var string $start_date Only return assignments after this date
      *     @var string $end_date Only return assignments before this date
-     *     @var string $state Only return assignments before this date
+     *     @var string $state Pass "active" to only return assignments for currently active users
      * }
      */
     public function __construct(array $queryParameters = [])

--- a/generated/Endpoint/ListPeople.php
+++ b/generated/Endpoint/ListPeople.php
@@ -15,6 +15,19 @@ class ListPeople extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Ja
 {
     use \Jane\OpenApiRuntime\Client\Psr7EndpointTrait;
 
+    /**
+     * Returns a list of people.
+     *
+     * @param array $queryParameters {
+     *
+     *     @var string $state Pass "active" to only return active users. Any other value also returns archived users.
+     * }
+     */
+    public function __construct(array $queryParameters = [])
+    {
+        $this->queryParameters = $queryParameters;
+    }
+
     public function getMethod(): string
     {
         return 'GET';
@@ -38,6 +51,17 @@ class ListPeople extends \Jane\OpenApiRuntime\Client\BaseEndpoint implements \Ja
     public function getAuthenticationScopes(): array
     {
         return ['BearerAuth', 'AccountAuth'];
+    }
+
+    protected function getQueryOptionsResolver(): \Symfony\Component\OptionsResolver\OptionsResolver
+    {
+        $optionsResolver = parent::getQueryOptionsResolver();
+        $optionsResolver->setDefined(['state']);
+        $optionsResolver->setRequired([]);
+        $optionsResolver->setDefaults([]);
+        $optionsResolver->setAllowedTypes('state', ['string']);
+
+        return $optionsResolver;
     }
 
     /**


### PR DESCRIPTION
 * fixed the `/assignments` "`state`" query parameter description
 * added the "`state`" query parameter on the `/people` endpoint - this changes the prototype of the client's `listPeople()` method